### PR TITLE
Added link for reset URL using localIP()

### DIFF
--- a/package/libraries/ArduinoTFTP/examples/WebServerWithReset/WebServerWithReset.ino
+++ b/package/libraries/ArduinoTFTP/examples/WebServerWithReset/WebServerWithReset.ino
@@ -121,6 +121,11 @@ void loop() {
           client.println();
           client.println("<!DOCTYPE HTML>");
           client.println("<html>");
+          client.print("<a href=\"http://");
+          client.print(Ethernet.localIP());
+          client.print(":81\">Reset me @ http://");
+          client.print(Ethernet.localIP());
+          client.print(":81</a></p>");
                     // add a meta refresh tag, so the browser pulls again every 5 seconds:
           client.println("<meta http-equiv=\"refresh\" content=\"5\">");
           // output the value of each analog input pin


### PR DESCRIPTION
The webpage will now show a link to reset the Arduino which is at port 81.  It pulls the IP from the Ethernet.localIP() which is created earlier in the sketch.
Example:
Reset me @ http://192.168.1.1:81
